### PR TITLE
Allow custom selection command names

### DIFF
--- a/spec/text-select-mode-spec.coffee
+++ b/spec/text-select-mode-spec.coffee
@@ -97,3 +97,13 @@ describe "TextSelectMode", ->
             expect(editor.getCursorBufferPosition().row).toBe(0)
             expect(editor.getCursorBufferPosition().column).toBe(1)
             expect(editor.getSelectedText()).toBe("L")
+
+          it "and works with end command", ->
+            toggle()
+            atom.commands.dispatch editorView, 'editor:move-to-end-of-screen-line'
+            atom.commands.dispatch editorView, 'core:move-left'
+            toggle()
+            atom.commands.dispatch editorView, 'editor:move-to-end-of-screen-line'
+            expect(editor.getCursorBufferPosition().row).toBe(0)
+            expect(editor.getCursorBufferPosition().column).toBe(123)
+            expect(editor.getSelectedText()).toBe(".")


### PR DESCRIPTION
This version uses dictionary to match movement and selection commands.
Old behavior (replacing `move` with `select`) is used by default.

Enables proper handling of the following commands:
- `core:page-up`
- `core:page-down`
- `editor:move-to-end-of-screen-line`
